### PR TITLE
Updated code to use RestSharp to create HTTP requests

### DIFF
--- a/click2mailVBNET/Restc2mAPI.vb
+++ b/click2mailVBNET/Restc2mAPI.vb
@@ -2,6 +2,8 @@
 Imports System.Xml
 Imports System.Net
 Imports System.IO
+Imports RestSharp
+Imports RestSharp.Authenticators
 
 Public Class Restc2mAPI
     Dim _username As String = ""
@@ -32,6 +34,7 @@ Public Class Restc2mAPI
     Private Function parseReturnxml(strxml As String, lookfor As String) As String
 
         Dim s As String = 0
+        Console.WriteLine("strxml = " + strxml)
 
         ' Create an XmlReader
         Using reader As XmlReader = XmlReader.Create(New StringReader(strxml))
@@ -65,7 +68,7 @@ Public Class Restc2mAPI
         Dim results As String
         Dim y As System.Collections.Specialized.NameValueCollection = New Specialized.NameValueCollection
         y.Clear()
-        results = createJobPost(getRestURL() & "/molpro/jobs/" & jobId, y, "GET")
+        results = createJobPost(getRestURL() & "/molpro/jobs/" & jobId, y, Method.GET)
         RaiseEvent jobStatusCheck(parseReturnxml(results, "id"), parseReturnxml(results, "status"), parseReturnxml(results, "description"))
         Return results
     End Function
@@ -73,7 +76,7 @@ Public Class Restc2mAPI
         Dim results As String
         Dim y As System.Collections.Specialized.NameValueCollection = New Specialized.NameValueCollection
         y.Add("billingType", "User Credit")
-        results = createJobPost(getRestURL() & "/molpro/jobs/" & jobId & "/submit", y, "POST")
+        results = createJobPost(getRestURL() & "/molpro/jobs/" & jobId & "/submit", y, Method.POST)
         Return results
     End Function
     Public Function createJobSimple(docClass As String, layout As String, productionTime As String, envelope As String, color As String, papertype As String, printOption As String) As String
@@ -90,22 +93,22 @@ Public Class Restc2mAPI
         y.Add("documentId", documentId)
         y.Add("addressId", addressListId)
         Dim results As String
-        results = createJobPost(getRestURL() & "/molpro/jobs", y, "POST")
+        results = createJobPost(getRestURL() & "/molpro/jobs", y, Method.POST)
         jobId = parseReturnxml(results, "id")
         Return jobId
     End Function
     Public Sub waitForCompletedAddressList()
         Dim y As System.Collections.Specialized.NameValueCollection = New Specialized.NameValueCollection
-
+        y.Clear()
         Dim status As String = "0"
         Dim results As String = "0"
-        results = createJobPost(getRestURL() & "/molpro/addressLists/" & addressListId, y, "GET")
+        results = createJobPost(getRestURL() & "/molpro/addressLists/" & addressListId, y, Method.GET)
         status = parseReturnxml(results, "status")
         If (status <> "3") Then
 
             While (status <> "3")
                 RaiseEvent statusChanged("Waiting Address List to processes.  Current Status is: " & status)
-                results = createJobPost(getRestURL() & "/molpro/addressLists/" & addressListId, y, "GET")
+                results = createJobPost(getRestURL() & "/molpro/addressLists/" & addressListId, y, Method.GET)
                 status = parseReturnxml(results, "status")
                 System.Threading.Thread.Sleep(5000)
             End While
@@ -176,83 +179,25 @@ Public Class Restc2mAPI
             Return _sRestmainurl
         End If
     End Function
-    Private Function createAddressList( _
-   ByVal uri As String, _
-   xml As String) As String
+    Function createAddressList( _
+                                  ByVal uri As String, _
+                                  xml As String) As String
         Dim responseText As String = ""
-        Dim request As Net.HttpWebRequest = Net.WebRequest.Create(uri)
-
-        request.ContentType = "application/xml"
-        request.Method = "POST"
-        request.KeepAlive = True
-        'request.Credentials = Net.CredentialCache.DefaultCredentials
-
-        Dim authinfo As String
-        authinfo = Convert.ToBase64String(Encoding.Default.GetBytes(_authinfo))
-        request.Headers("Authorization") = "Basic " + authinfo
-
-        Using requestStream As IO.Stream = request.GetRequestStream()
-
-            Using fileStream As Stream = GenerateStreamFromString(xml)
-
-                Dim buffer(4096) As Byte
-                Dim bytesRead As Int32 = fileStream.Read(buffer, 0, buffer.Length)
-
-                Do While (bytesRead > 0)
-
-                    requestStream.Write(buffer, 0, bytesRead)
-                    bytesRead = fileStream.Read(buffer, 0, buffer.Length)
-
-                Loop
-
-            End Using
-
-
-
-        End Using
-
-        Dim response As Net.WebResponse = Nothing
-
-        Try
-
-            response = request.GetResponse()
-
-            Using responseStream As IO.Stream = response.GetResponseStream()
-
-                Using responseReader As New IO.StreamReader(responseStream)
-
-                    responseText = responseReader.ReadToEnd()
-
-
-                End Using
-
-            End Using
-
-        Catch exception As Net.WebException
-
-            response = exception.Response
-
-            If (response IsNot Nothing) Then
-
-                Using reader As New IO.StreamReader(response.GetResponseStream())
-
-                    responseText = reader.ReadToEnd()
-
-
-                End Using
-
-                response.Close()
-
-            End If
-
-        Finally
-
-            request = Nothing
-
-        End Try
+        Dim client As RestClient = New RestClient()
+        client.Authenticator = new HttpBasicAuthenticator(_username, _password)
+        
+        Dim request as RestRequest = New RestRequest(uri, Method.POST)
+        request.AddHeader("Content-Type", "application/xml")
+        request.AddHeader("Accept", "*/*")
+        request.AddParameter("application/xml", xml, ParameterType.RequestBody)
+        
+        Console.WriteLine(xml)
+        
+        Dim response as IRestResponse  = client.Post(request)
+        responseText = response.Content
         Return responseText
-
     End Function
+    
 
     Public Enum liveMode
         Live = True
@@ -281,82 +226,32 @@ Public Class Restc2mAPI
         Return newString.ToString()
 
     End Function
-    Public Function createJobPost(url As String, nameValueCollection As Specialized.NameValueCollection, Method As String) As String
+    Public Function createJobPost(url As String, nameValueCollection As Specialized.NameValueCollection, method As Method) As String
         ' Here we convert the nameValueCollection to POST data.
         ' This will only work if nameValueCollection contains some items.
-        Dim parameters = New StringBuilder()
         Dim responseText As String = ""
+        Dim client As RestClient = New RestClient()
+        client.Authenticator = new HttpBasicAuthenticator(_username, _password)
+        
+        Dim request as RestRequest = New RestRequest(url, method)
+        request.AddHeader("Content-Type", "application/x-www-form-urlencoded")
+        request.AddHeader("Accept", "*/*")
+        
         For Each key As String In nameValueCollection.Keys
-            parameters.AppendFormat("{0}={1}&", WebUtility.UrlEncode(key), WebUtility.UrlEncode(nameValueCollection(key)))
-        Next
-        If (parameters.Length > 0) Then
-            parameters.Length -= 1
-        End If
-
-        ' Here we create the request and write the POST data to it.
-        Dim request = DirectCast(HttpWebRequest.Create(url), HttpWebRequest)
-        request.Method = Method
-        request.KeepAlive = True
-        'request.Credentials = Net.CredentialCache.DefaultCredentials
-
-        Dim authinfo As String
-        authinfo = Convert.ToBase64String(Encoding.Default.GetBytes(_authinfo))
-        request.Headers("Authorization") = "Basic " + authinfo
-
-        If (parameters.Length > 0) Then
-            Using writer = New StreamWriter(request.GetRequestStream())
-                writer.Write(parameters.ToString())
-            End Using
-        End If
-
-        Dim response As Net.WebResponse = Nothing
-
-        Try
-
-            response = request.GetResponse()
-
-            Using responseStream As IO.Stream = response.GetResponseStream()
-
-                Using responseReader As New IO.StreamReader(responseStream)
-
-                    responseText = responseReader.ReadToEnd()
-
-
-                End Using
-
-            End Using
-
-        Catch exception As Net.WebException
-
-            response = exception.Response
-
-            If (response IsNot Nothing) Then
-
-                Using reader As New IO.StreamReader(response.GetResponseStream())
-
-                    responseText = reader.ReadToEnd()
-
-
-                End Using
-
-                response.Close()
-
-            End If
-
-        Finally
-
-            request = Nothing
-
-        End Try
-        Return responseText
+            request.AddParameter(key, nameValueCollection(key))
+        Next key
+        
+        Dim response as IRestResponse  = if (method.Equals(RestSharp.Method.POST), client.Post(request), client.Get(request))
+        responseText = response.Content
+        return responseText
     End Function
 
     Public Function createXMLFromAddressList() As String
         Dim doc As New Xml.XmlDocument
+        
         'create nodes
         Dim root As Xml.XmlElement = doc.CreateElement("addressList")
-
-
+        
         Dim addressListName As Xml.XmlElement = doc.CreateElement("addressListName")
         _addressListName = Guid.NewGuid().ToString("N")
         addressListName.InnerXml = _addressListName
@@ -406,15 +301,18 @@ Public Class Restc2mAPI
         Next
 
         doc.AppendChild(root)
+        
         Dim xmlString As String
+        Dim settings As XmlWriterSettings  = new XmlWriterSettings()
+        settings.OmitXmlDeclaration = True
         Using stringWriter = New StringWriter()
-            Using xmlTextWriter = XmlWriter.Create(stringWriter)
+            Using xmlTextWriter = XmlWriter.Create(stringWriter, settings)
                 doc.WriteTo(xmlTextWriter)
                 xmlTextWriter.Flush()
-
                 xmlString = stringWriter.GetStringBuilder().ToString()
             End Using
         End Using
+        
         Return xmlString
 
     End Function
@@ -468,99 +366,21 @@ Public Class Restc2mAPI
      ByVal contentType As String, _
      ByVal otherParameters As Specialized.NameValueCollection) As String
         Dim responseText As String = ""
-        Dim boundary As String = "---------------------------" & DateTime.Now.Ticks.ToString("x")
-        Dim newLine As String = System.Environment.NewLine
-        Dim boundaryBytes As Byte() = Text.Encoding.ASCII.GetBytes(newLine & "--" & boundary & newLine)
-        Dim request As Net.HttpWebRequest = Net.WebRequest.Create(uri)
-
-        request.ContentType = "multipart/form-data; boundary=" & boundary
-        request.Method = "POST"
-        request.KeepAlive = True
-        'request.Credentials = Net.CredentialCache.DefaultCredentials
-
-        Dim authinfo As String
-        authinfo = Convert.ToBase64String(Encoding.Default.GetBytes(_authinfo))
-        request.Headers("Authorization") = "Basic " + authinfo
-
-        Using requestStream As IO.Stream = request.GetRequestStream()
-
-            Dim formDataTemplate As String = "Content-Disposition: form-data; name=""{0}""{1}Content-Type: text/plain; charset=UTF-8{1}{1}{2}"
-
-            For Each key As String In otherParameters.Keys
-
-                requestStream.Write(boundaryBytes, 0, boundaryBytes.Length)
-                Dim formItem As String = String.Format(formDataTemplate, key, newLine, otherParameters(key))
-                Dim formItemBytes As Byte() = Text.Encoding.UTF8.GetBytes(formItem)
-                requestStream.Write(formItemBytes, 0, formItemBytes.Length)
-
-            Next key
-
-            requestStream.Write(boundaryBytes, 0, boundaryBytes.Length)
-
-            Dim headerTemplate As String = "Content-Disposition: form-data; name=""{0}""; filename=""{1}""{2}Content-Type: {3}{2}Content-Transfer-Encoding: binary{2}{2}"
-            Dim header As String = String.Format(headerTemplate, fileParameterName, filePath, newLine, contentType)
-            Dim headerBytes As Byte() = Text.Encoding.UTF8.GetBytes(header)
-            requestStream.Write(headerBytes, 0, headerBytes.Length)
-
-            Using fileStream As New IO.FileStream(filePath, IO.FileMode.Open, IO.FileAccess.Read)
-
-                Dim buffer(4096) As Byte
-                Dim bytesRead As Int32 = fileStream.Read(buffer, 0, buffer.Length)
-
-                Do While (bytesRead > 0)
-
-                    requestStream.Write(buffer, 0, bytesRead)
-                    bytesRead = fileStream.Read(buffer, 0, buffer.Length)
-
-                Loop
-
-            End Using
-
-            Dim trailer As Byte() = Text.Encoding.ASCII.GetBytes(newLine & "--" + boundary + "--" & newLine)
-            requestStream.Write(trailer, 0, trailer.Length)
-
-        End Using
-
-        Dim response As Net.WebResponse = Nothing
-
-        Try
-
-            response = request.GetResponse()
-
-            Using responseStream As IO.Stream = response.GetResponseStream()
-
-                Using responseReader As New IO.StreamReader(responseStream)
-
-                    responseText = responseReader.ReadToEnd()
-
-
-                End Using
-
-            End Using
-
-        Catch exception As Net.WebException
-
-            response = exception.Response
-
-            If (response IsNot Nothing) Then
-
-                Using reader As New IO.StreamReader(response.GetResponseStream())
-
-                    responseText = reader.ReadToEnd()
-
-
-                End Using
-
-                response.Close()
-
-            End If
-
-        Finally
-
-            request = Nothing
-
-        End Try
+        Dim client As RestClient = New RestClient()
+        client.Authenticator = new HttpBasicAuthenticator(_username, _password)
+        
+        Dim request as RestRequest = New RestRequest(uri, Method.POST)
+        request.AddHeader("Content-Type", "multipart/form-data")
+        request.AddHeader("Accept", "application/xml")
+        
+        request.AddFile(fileParameterName, filePath)
+        For Each key As String In otherParameters.Keys
+            request.AddParameter(key, otherParameters(key))
+        Next key
+        
+        Dim response as IRestResponse  = client.Post(request)
+        responseText = response.Content
         Return responseText
-
     End Function
+
 End Class

--- a/click2mailVBNET/packages.config
+++ b/click2mailVBNET/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="RestSharp" version="106.12.0" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
For security, we now have strict HTTPS and we have to use RestSharp to create compliant HTTPS requests with the correct headers.